### PR TITLE
[FIX] @get /v1/end/{id} 500 에러 해결

### DIFF
--- a/app/src/main/java/com/timi/seulseul/presentation/location/activity/LocationActivity.kt
+++ b/app/src/main/java/com/timi/seulseul/presentation/location/activity/LocationActivity.kt
@@ -64,7 +64,7 @@ class LocationActivity : BaseActivity<ActivityLocationBinding>(R.layout.activity
         super.onResume()
 
         coroutineScope.launch {
-            delay(1500)
+            delay(2000)
             viewModel.getEndLocation()
         }
 


### PR DESCRIPTION
## 💡 Issue
close #100 

## 🌱 Key changes
- 리사이클러뷰 아이템에 뜨는 요소들을 2초 이후에 뜨도록 delay 값을 수정했습니다.

## ✅ To Reviewers
- @get /v1/end/{id} 통신은 @post /v1/start 통신이 완료 되어야지만 가능합니다.
- 그래서 @get /v1/end/{id} 통신을 진행하는 아이템 클릭 리스너 전에 post 통신이 되도록 delay 를 post 통신보다 1초 느린 2초로 수정했습니다.